### PR TITLE
Minor bug fix.

### DIFF
--- a/Transcription regulation network/propensity.m
+++ b/Transcription regulation network/propensity.m
@@ -29,7 +29,7 @@ if j==6
 end
 
 if j==7
-    a=K(7)*N*X(1)*(N*X(1)-1);
+    a=abs(K(7)*N*X(1)*(N*X(1)-1));
 end
 
 if j==8


### PR DESCRIPTION
There was a problem here if X(1) = 0. In this case we have a = 0*(-1). Mathematically a = 0, but in programming 0*(-1) = -0. This becomes a problem when we calculate deltaT (in modified_next_reaction_method_full_model.m): instead of 1/0 = Inf we get 1/(-0) = -Inf, because of which further simulation works incorrectly. 
With default parameters this bug affects the program only at the very beginning of the calculation of filters with the full model, when X(1) = 0 occurs in some particles. _That is why in the numerical example (fig. 6-7), filters for boundDNA are different at the first few minutes (after the fix, this difference is gone)._
If we use abs, we make sure that we always get exactly +0. Mathematically it doesn't change anything.